### PR TITLE
Make admission plugins configurable for kube api server

### DIFF
--- a/aws/cluster/cluster-spec-template.tf
+++ b/aws/cluster/cluster-spec-template.tf
@@ -62,6 +62,7 @@ EOF
     apiserver-runtime-config = "${join("\n", data.template_file.apiserver-runtime-configs.*.rendered)}"
     featuregates-config      = "${join("\n", data.template_file.featuregates-configs.*.rendered)}"
     oidc-config              = "${join("\n", data.template_file.oidc-apiserver-conf.*.rendered)}"
+    enable-admission-plugins = "${trimspace(join("", data.template_file.enable-admission-plugins.*.rendered))}"
 
     # kube-controller-manager configuration
     hpa-sync-period                     = "${var.hpa-sync-period}"
@@ -221,5 +222,17 @@ EOF
 
   vars {
     sysctl = "${element(var.allowed-unsafe-sysctls, count.index)}"
+  }
+}
+
+data "template_file" "enable-admission-plugins" {
+  count = "${length(var.enable-admission-plugins)}"
+
+  template = <<EOF
+    - $${plugin}
+EOF
+
+  vars {
+    plugin = "${element(var.enable-admission-plugins, count.index)}"
   }
 }

--- a/aws/cluster/templates/cluster-spec.yaml
+++ b/aws/cluster/templates/cluster-spec.yaml
@@ -25,20 +25,7 @@ ${etcd-clusters}
   kubeAPIServer:
     insecureBindAddress: 127.0.0.1
     enableAdmissionPlugins:
-    - NamespaceLifecycle
-    - LimitRanger
-    - ServiceAccount
-    - PersistentVolumeLabel
-    - DefaultStorageClass
-    - DefaultTolerationSeconds
-    - NodeRestriction
-    - Priority
-    - DenyEscalatingExec
-    - PodPreset
-    - MutatingAdmissionWebhook
-    - ValidatingAdmissionWebhook
-    - ResourceQuota
-    - PersistentVolumeClaimResize
+    ${enable-admission-plugins}
     allowPrivileged: true
     anonymousAuth: false
     apiServerCount: ${master-count}

--- a/aws/cluster/variables.tf
+++ b/aws/cluster/variables.tf
@@ -196,6 +196,28 @@ variable "featuregates-flags" {
   }
 }
 
+variable "enable-admission-plugins" {
+  type        = "list"
+  description = "List of enabled admission plugins"
+
+  default = [
+    "NamespaceLifecycle",
+    "LimitRanger",
+    "ServiceAccount",
+    "PersistentVolumeLabel",
+    "DefaultStorageClass",
+    "DefaultTolerationSeconds",
+    "NodeRestriction",
+    "Priority",
+    "DenyEscalatingExec",
+    "PodPreset",
+    "MutatingAdmissionWebhook",
+    "ValidatingAdmissionWebhook",
+    "ResourceQuota",
+    "PersistentVolumeClaimResize"
+  ]
+}
+
 variable "hpa-sync-period" {
   type        = "string"
   description = "The frequency at which HPA are evaluated and reconciled"


### PR DESCRIPTION
The template for kops that is generated from cluster-spec.yaml is identical as before this PR, so it will not cause rolling update, yet it allows customizing the set of admission plugins if needed.