### PR TITLE
Add support to allow concurrency of image pulls and change pull timeout

### DIFF
--- a/aws/cluster/cluster-spec-template.tf
+++ b/aws/cluster/cluster-spec-template.tf
@@ -68,8 +68,8 @@ EOF
     enable-admission-plugins = "${trimspace(join("", data.template_file.enable-admission-plugins.*.rendered))}"
 
     # kube-controller-manager configuration
-    hpa-sync-period                     = "${var.hpa-sync-period}"
-    hpa-scale-downscale-stabilization   = "${var.hpa-scale-downscale-stabilization}"
+    hpa-sync-period                   = "${var.hpa-sync-period}"
+    hpa-scale-downscale-stabilization = "${var.hpa-scale-downscale-stabilization}"
 
     # Additional IAM policies for masters and nodes
     master-additional-policies = "${length(var.master-additional-policies) == 0 ? "" : format("master: |\n      %s", indent(6, var.master-additional-policies))}"
@@ -83,10 +83,10 @@ EOF
     kubernetes-cpu-cfs-quota-period  = "${var.kubernetes-cpu-cfs-quota-period}"
 
     # Set allowed-unsafe-sysctls so we can tweak them in containers
-    allowed-unsafe-sysctls   = "${join("\n", data.template_file.allowed-unsafe-sysctls.*.rendered)}"
+    allowed-unsafe-sysctls = "${join("\n", data.template_file.allowed-unsafe-sysctls.*.rendered)}"
 
     # Improve image pull concurrency
-    serialize-image-pulls = "${var.serialize-image-pulls-enabled}"
+    serialize-image-pulls        = "${var.serialize-image-pulls-enabled}"
     image-pull-progress-deadline = "${var.image-pull-progress-deadline}"
   }
 }

--- a/aws/cluster/cluster-spec-template.tf
+++ b/aws/cluster/cluster-spec-template.tf
@@ -84,6 +84,10 @@ EOF
 
     # Set allowed-unsafe-sysctls so we can tweak them in containers
     allowed-unsafe-sysctls   = "${join("\n", data.template_file.allowed-unsafe-sysctls.*.rendered)}"
+
+    # Improve image pull concurrency
+    serialize-image-pulls = "${var.serialize-image-pulls-enabled}"
+    image-pull-progress-deadline = "${var.image-pull-progress-deadline}"
   }
 }
 

--- a/aws/cluster/templates/cluster-spec.yaml
+++ b/aws/cluster/templates/cluster-spec.yaml
@@ -87,6 +87,8 @@ ${allowed-unsafe-sysctls}
     anonymousAuth: true
     cpuCFSQuota: ${kubernetes-cpu-cfs-quota-enabled}
     cpuCFSQuotaPeriod: "${kubernetes-cpu-cfs-quota-period}"
+    serializeImagePulls: ${serialize-image-pulls}
+    imagePullProgressDeadline: "${image-pull-progress-deadline}"
     allowPrivileged: true
     cgroupRoot: /
     cloudProvider: aws

--- a/aws/cluster/variables.tf
+++ b/aws/cluster/variables.tf
@@ -683,6 +683,18 @@ variable "kubernetes-cpu-cfs-quota-period" {
   default     = "100ms"
 }
 
+variable "serialize-image-pulls-enabled" {
+  type        = "string"
+  description = "Boolean (true or false) enable or disable serializeImagePulls (serialize-image-pulls). If disabled Docker default download concurrency is 3."
+  default     = "true"
+}
+
+variable "image-pull-progress-deadline" {
+  type        = "string"
+  description = "Set a time period for imagePullProgressDeadline (image-pull-progress-deadline)"
+  default     = "1m"
+}
+
 variable "allowed-unsafe-sysctls" {
   type        = "list"
   description = "List of sysctls to allow override - allowedUnsafeSysctls (allowed-unsafe-sysctls)"


### PR DESCRIPTION
Docker default concurrency is three but Kubelet serializes pulls.
This is at least an improvement on pulling serially one at a time and allows increasing the timeout for pulls which can be long for various reasons.

https://github.com/kubernetes/kops/blob/release-1.14/pkg/apis/kops/v1alpha2/componentconfig.go