### PR TITLE
Add support for setting dockerconfig on Karch

### DIFF
--- a/aws/cluster/main.tf
+++ b/aws/cluster/main.tf
@@ -113,3 +113,18 @@ EOF
 
   depends_on = [null_resource.kops-cluster]
 }
+
+// Cluster Docker Login Configuration on S3
+// Short version of https://github.com/kubernetes/kops/blob/master/docs/cli/kops_create_secret_dockerconfig.md
+// Kops version currently subject to bugs and doesn't trigger rolling upgrade so no need to complicate as per cluster-spec.
+resource "aws_s3_bucket_object" "docker-auth-config" {
+  count  = var.docker-auth-config != "" ? 1 : 0
+  bucket = var.kops-state-bucket
+  key    = "/${var.cluster-name}/secrets/dockerconfig"
+
+  content = <<EOF
+{"Data":"${var.docker-auth-config}"}
+EOF
+
+  depends_on = ["null_resource.kops-cluster"]
+}

--- a/aws/cluster/main.tf
+++ b/aws/cluster/main.tf
@@ -126,5 +126,5 @@ resource "aws_s3_bucket_object" "docker-auth-config" {
 {"Data":"${var.docker-auth-config}"}
 EOF
 
-  depends_on = ["null_resource.kops-cluster"]
+  depends_on = [null_resource.kops-cluster]
 }

--- a/aws/cluster/variables.tf
+++ b/aws/cluster/variables.tf
@@ -658,3 +658,9 @@ variable "allowed-unsafe-sysctls" {
   description = "List of sysctls to allow override - allowedUnsafeSysctls (allowed-unsafe-sysctls)"
   default     = []
 }
+
+variable "docker-auth-config" {
+  type        = "string"
+  description = "Base64 encoded ~/.docker/config.json for Docker Hub login"
+  default     = ""
+}


### PR DESCRIPTION
A shortcut to achieving [kops_create_secret_dockerconfig.md](https://github.com/kubernetes/kops/blob/master/docs/cli/kops_create_secret_dockerconfig.md) to be able to ship any size `~/.docker/config.json` with various details required for a cluster to interact with repos.