### PR TITLE
JSCCE-30520: remove deprecated admission plugin DenyEscalatingExec

### DIFF
--- a/aws/cluster/variables.tf
+++ b/aws/cluster/variables.tf
@@ -374,7 +374,6 @@ variable "enable-admission-plugins" {
   default = [
     "DefaultStorageClass",
     "DefaultTolerationSeconds",
-    "DenyEscalatingExec",
     "LimitRanger",
     "MutatingAdmissionWebhook",
     "NamespaceLifecycle",


### PR DESCRIPTION
1.21.14 cluster creation with kOps fails, kube-api server fails with:
```
2022-11-17T08:57:49.70463905Z stderr F Error: enable-admission-plugins plugin "DenyEscalatingExec" is unknown
```

The DenyEscalatingExec admission plugin is deprecated.
Use of a policy-based admission plugin (like [PodSecurityPolicy](https://v1-21.docs.kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#podsecuritypolicy) or a custom admission plugin) which can be targeted at specific users or Namespaces and also protects against creation of overly privileged Pods is recommended instead.